### PR TITLE
prevent unnecessary DB updates if patient data is unchanged after patch

### DIFF
--- a/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/constants/ApplicationConstants.java
+++ b/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/constants/ApplicationConstants.java
@@ -30,13 +30,11 @@ public class ApplicationConstants {
     public static final String DOCTORS_COLLECTION = "tp_doctors";
     public static final String DOCTORS_NOT_FOUND = "No Doctors found";
     public static final String EMPTY_NAME_QUERY_PARAM = "Query parameter 'name' cannot be empty. Please provide either a first name or a last name to filter";
-    public static final String FAILED_TO_APPLY = "Failed to apply";
     public static final String FIRST_NAME = "firstName";
     public static final String ID = "_id";
     public static final String INVALID_URL = "Invalid URL";
     public static final String LAST_NAME = "lastName";
     public static final String NO_PATIENTS_FOUND = "No patients found";
-    public static final String ON = "on";
     public static final String PARAM_DOCTOR_NAME = "name";
     public static final String PATIENT_COLLECTION = "tp_patients";
     public static final String PATIENT_ID = "patientId";
@@ -48,7 +46,6 @@ public class ApplicationConstants {
     public static final String PATCH_PATH_LAST_NAME = "/lastName";
     public static final String PATCH_REMOVE_OPERATION = "remove";
     public static final String PATCH_REPLACE_OPERATION = "replace";
-    public static final String PATCH_VALUE_KEY = "value";
     public static final String PATIENTS = "patients";
     public static final String QUERY_PARAMS_CANNOT_NULL = "Query params cannot be null.";
     public static final String REGEX_ALPHABET_PATTERN = "^[a-zA-Z\\s]+$";

--- a/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/exceptionhandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/exceptionhandler/GlobalExceptionHandler.java
@@ -148,7 +148,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(PatientAlreadyAssignedException.class)
     public ResponseEntity<BaseResponse> handlePatientAlreadyAssigned(PatientAlreadyAssignedException patientAlreadyAssignedException) {
         BaseResponse baseResponse = BaseResponse.builder().success(false).errors(List.of(patientAlreadyAssignedException.getMessage())).build();
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(baseResponse);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(baseResponse);
     }
 
     @ExceptionHandler(JsonPatchProcessingException.class)

--- a/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/rest/controller/patient/PatientDeletionController.java
+++ b/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/rest/controller/patient/PatientDeletionController.java
@@ -23,7 +23,7 @@ public class PatientDeletionController {
     }
 
     @DeleteMapping(ApiConstants.PATIENT_ID)
-    public ResponseEntity<BaseResponse> deletePatientController(@PathVariable String patientId) throws Exception {
+    public ResponseEntity<BaseResponse> deletePatientById(@PathVariable String patientId) throws Exception {
         return patientDeletionResourceService.deletePatientById(patientId);
     }
 }

--- a/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/rest/controller/patient/PatientDeletionController.java
+++ b/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/rest/controller/patient/PatientDeletionController.java
@@ -1,9 +1,6 @@
 package com.elixrlabs.doctorpatientmanagementsystem.rest.controller.patient;
 
 import com.elixrlabs.doctorpatientmanagementsystem.constants.ApiConstants;
-import com.elixrlabs.doctorpatientmanagementsystem.exceptionhandler.DataNotFoundException;
-import com.elixrlabs.doctorpatientmanagementsystem.exceptionhandler.EmptyUuidException;
-import com.elixrlabs.doctorpatientmanagementsystem.exceptionhandler.PatientAlreadyAssignedException;
 import com.elixrlabs.doctorpatientmanagementsystem.response.BaseResponse;
 import com.elixrlabs.doctorpatientmanagementsystem.service.patient.PatientDeletionService;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +23,7 @@ public class PatientDeletionController {
     }
 
     @DeleteMapping(ApiConstants.PATIENT_ID)
-    public ResponseEntity<BaseResponse> ResponseDto(@PathVariable String patientId) throws Exception {
+    public ResponseEntity<BaseResponse> deletePatientController(@PathVariable String patientId) throws Exception {
         return patientDeletionResourceService.deletePatientById(patientId);
     }
 }

--- a/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/service/patient/PatientModificationService.java
+++ b/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/service/patient/PatientModificationService.java
@@ -36,8 +36,7 @@ public class PatientModificationService {
     public PatientModificationService(PatientRepository patientRepository,
                                       ObjectMapper objectMapper,
                                       PatientValidation patientValidation,
-                                      MessageUtil messageUtil
-    ) {
+                                      MessageUtil messageUtil) {
         this.patientRepository = patientRepository;
         this.objectMapper = objectMapper;
         this.patientValidation = patientValidation;

--- a/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/validation/JsonPatchValidator.java
+++ b/src/main/java/com/elixrlabs/doctorpatientmanagementsystem/validation/JsonPatchValidator.java
@@ -3,7 +3,6 @@ package com.elixrlabs.doctorpatientmanagementsystem.validation;
 import com.elixrlabs.doctorpatientmanagementsystem.constants.ApplicationConstants;
 import com.elixrlabs.doctorpatientmanagementsystem.enums.MessageKeyEnum;
 import com.elixrlabs.doctorpatientmanagementsystem.exceptionhandler.InvalidJsonOperationException;
-import com.elixrlabs.doctorpatientmanagementsystem.repository.patient.PatientRepository;
 import com.elixrlabs.doctorpatientmanagementsystem.util.MessageUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,43 +12,24 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * This class is responsible for validating JSON Patch operations
- * before they are applied to the Doctor entity.
- * It checks for:
- * - Disallowed operations like 'add' and 'remove'
- * - Restricted paths like replacing the 'id' field
- */
-
 @Component
 public class JsonPatchValidator {
 
     private final MessageUtil messageUtil;
-    private final PatientRepository patientRepository;
 
-    public JsonPatchValidator(MessageUtil messageUtil, PatientRepository patientRepository) {
+    public JsonPatchValidator(MessageUtil messageUtil) {
         this.messageUtil = messageUtil;
-        this.patientRepository = patientRepository;
     }
-
-    /**
-     * Validates a JSON Patch request to ensure only allowed operations and paths are used.
-     * <p>
-     * - Rejects 'add' and 'remove' operations<br>
-     * - Allows 'replace' operation only on firstName, lastName, and department fields
-     *
-     * @param patch the JSON Patch request with a list of operations
-     * @throws InvalidJsonOperationException if any invalid operation or path is found
-     */
 
     public void validateJsonOperations(JsonPatch patch) throws InvalidJsonOperationException {
         List<String> errors = new ArrayList<>();
         ObjectMapper mapper = new ObjectMapper();
         JsonNode patchNode = mapper.valueToTree(patch);
+
         for (JsonNode patchOperation : patchNode) {
             String operationType = patchOperation.get(ApplicationConstants.PATCH_OPERATION_KEY).asText();
             String path = patchOperation.get(ApplicationConstants.PATCH_PATH_KEY).asText();
-            String Value = patchOperation.get(ApplicationConstants.PATCH_VALUE_KEY).asText();
+
             if (ApplicationConstants.PATCH_ADD_OPERATION.equalsIgnoreCase(operationType)) {
                 String message = messageUtil.getMessage(MessageKeyEnum.ADD_OPERATION_NOT_ALLOWED.getKey(), path);
                 errors.add(message);
@@ -63,24 +43,12 @@ public class JsonPatchValidator {
                 String message = messageUtil.getMessage(MessageKeyEnum.REPLACE_NON_EXISTENT_FIELD_NOT_ALLOWED.getKey(), path);
                 errors.add(message);
             }
-            if (ApplicationConstants.PATCH_PATH_FIRST_NAME.equalsIgnoreCase(path) && patientRepository.existsByFirstNameIgnoreCase(Value)) {
-                String message = messageUtil.getMessage(MessageKeyEnum.DUPLICATE_FIRST_NAME.getKey(), Value);
-                errors.add(message);
-                continue;
-            }
-            if (ApplicationConstants.PATCH_PATH_LAST_NAME.equalsIgnoreCase(path) && patientRepository.existsByLastNameIgnoreCase(Value)) {
-                String message = messageUtil.getMessage(MessageKeyEnum.DUPLICATE_LAST_NAME.getKey(), Value);
-                errors.add(message);
-            }
         }
         if (!errors.isEmpty()) {
             throw new InvalidJsonOperationException(errors);
         }
     }
 
-    /**
-     * Checks if the given path is allowed for 'replace' operation.
-     */
     private boolean isAllowedReplacePath(String path) {
         return path.equalsIgnoreCase(ApplicationConstants.PATCH_PATH_FIRST_NAME)
                 || path.equalsIgnoreCase(ApplicationConstants.PATCH_PATH_LAST_NAME)


### PR DESCRIPTION
1) Compared original and patched patient model fields
2)Skipped save operation where no changes where detected
3)Reused JsonPatchValidator
4)Changed method name to deletePatientController  , changed Http Response to BAD REQUEST.
![Assigned1](https://github.com/user-attachments/assets/3b5aaa5b-aea5-42e0-98d0-fd80d891d1b5)


![patch3](https://github.com/user-attachments/assets/3d0bd3fb-0113-4a94-b02e-e7cead1b2f9f)
![patch31](https://github.com/user-attachments/assets/a91ada19-dbdf-4824-a318-fbc193bbb5ef)
![patch32](https://github.com/user-attachments/assets/7f52d2b9-c403-46e2-b15d-31d288d7e80e)
![patch33](https://github.com/user-attachments/assets/851f8bbc-f04c-45b9-9ce4-64d3b7016c69)
